### PR TITLE
Day5-variableの章とnavigator設定を修正

### DIFF
--- a/ansible-navigator.yaml
+++ b/ansible-navigator.yaml
@@ -38,8 +38,8 @@ ansible-navigator:
   collection-doc-cache-path: /tmp/cache.db
 
   color:
-    enable: False
-    osc4: False
+    enable: true
+    osc4: true
 
   # editor:
   #   command: vim_from_setting

--- a/ansible_practice/05_variable/variable_exam_1.yml
+++ b/ansible_practice/05_variable/variable_exam_1.yml
@@ -5,9 +5,9 @@
 
   tasks:
     - name: set_fact
-      set_fact:
-        HelIo: "Hello Ansible!"
+      ansible.builtin.set_fact:
+        Hello: "Hello Ansible!"
 
     - name: debug
-      debug:
+      ansible.builtin.debug:
         var: Hello

--- a/ansible_practice/05_variable/variable_exam_1.yml
+++ b/ansible_practice/05_variable/variable_exam_1.yml
@@ -6,7 +6,7 @@
   tasks:
     - name: set_fact
       ansible.builtin.set_fact:
-        Hello: "Hello Ansible!"
+        HelIo: "Hello Ansible!"
 
     - name: debug
       ansible.builtin.debug:

--- a/ansible_practice/05_variable/variable_exam_2.yml
+++ b/ansible_practice/05_variable/variable_exam_2.yml
@@ -5,9 +5,9 @@
 
   tasks:
     - name: set_fact
-      set_fact:
+      ansible.builtin.set_fact:
         ansible_play_name: "Hello Ansible!"
 
     - name: debug
-      debug:
+      ansible.builtin.debug:
         var: ansible_play_name

--- a/ansible_practice/05_variable/variable_sample_1.yml
+++ b/ansible_practice/05_variable/variable_sample_1.yml
@@ -8,5 +8,5 @@
 
   tasks:
     - name: sample1 debug vars
-      debug:
+      ansible.builtin.debug:
         var: test

--- a/ansible_practice/05_variable/variable_sample_2.yml
+++ b/ansible_practice/05_variable/variable_sample_2.yml
@@ -5,9 +5,9 @@
 
   tasks:
     - name: sample2 set_fact
-      set_fact:
+      ansible.builtin.set_fact:
         test: "Hello Ansible!"
 
     - name: sample2 debug set_fact 
-      debug:
+      ansible.builtin.debug:
         var: test

--- a/ansible_practice/05_variable/variable_sample_3.yml
+++ b/ansible_practice/05_variable/variable_sample_3.yml
@@ -5,5 +5,5 @@
 
   tasks:
     - name: sample3 magic debug
-      debug:
+      ansible.builtin.debug:
         var: ansible_play_name

--- a/ansible_practice/05_variable/variable_sample_4.yml
+++ b/ansible_practice/05_variable/variable_sample_4.yml
@@ -4,9 +4,9 @@
 
   tasks:
     - name: debug ansible_facts
-      debug:
+      ansible.builtin.debug:
         var: ansible_facts
 
     - name: debug ansible_facts.net_hostname
-      debug:
+      ansible.builtin.debug:
         var: ansible_facts.net_hostname


### PR DESCRIPTION
- modify module name( &remove typo )
  - module名をFQCNに修正
- modify color style
  - ansible-navigator.yamlのcolor部分を修正して、terminalの出力にカラーを加えるように設定