### PR TITLE
Fix 95

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ pyyaml = "5.1"
 ansible-builder = "3.0.0"
 docker = "6.1.3"
 docutils = "0.20.1"
+requests = "2.31.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
pythonのrequests libを2.31.0に固定して、dockerとのdependency問題を回避した